### PR TITLE
Fix LanguageField incorrect super() call (Django 3.2 compatibility)

### DIFF
--- a/languages/fields.py
+++ b/languages/fields.py
@@ -10,4 +10,4 @@ class LanguageField(CharField):
 
         kwargs.setdefault('max_length', 3)
         kwargs.setdefault('choices', LANGUAGES)
-        super(CharField, self).__init__(*args, **kwargs)
+        super(LanguageField, self).__init__(*args, **kwargs)


### PR DESCRIPTION
I found that the Field was calling super(), but in a weird way, causing it to call the super() class of CharField, which is Field. I am not sure if this was by design, but it does not seem all that logical to me. It also broke compatibility with Django 3.2.

Please let me know what you think!