### PR TITLE
fix: fix ability to add custom keyword arguments

### DIFF
--- a/languages/fields.py
+++ b/languages/fields.py
@@ -4,10 +4,12 @@ class LanguageField(CharField):
     """
     A language field for Django models.
     """
-    def __init__(self, *args, db_collation=None, **kwargs):
+    def __init__(self, *args, **kwargs):
         # Local import so the languages aren't loaded unless they are needed.
         from .languages import LANGUAGES
 
         kwargs.setdefault('max_length', 3)
         kwargs.setdefault('choices', LANGUAGES)
-        super().__init__(*args, db_collation, **kwargs)
+        kwargs.setdefault('db_collation', None)
+
+        super().__init__(*args, **kwargs)


### PR DESCRIPTION
Previously, if you tried adding any keyword arguments in your model that uses a LanguageField an "unexpected argument" exception would be thrown because of the super call using a positional argument to pass `db_collation`.

With this fix I am able to use Django Language Field with Django 4.1.

I agree that my changes can be licensed under the MIT license or any other similar license the author chooses for the project in the future.